### PR TITLE
Implementation for bad fruits

### DIFF
--- a/ros_workspace/src/proyecto/src/commands.py
+++ b/ros_workspace/src/proyecto/src/commands.py
@@ -11,6 +11,8 @@ class Command(Enum):
     CAJA_MALA_ABAJO = 5
     ABRIR_PINZA = 6
     CERRAR_PINZA = 7
+    CERRAR_PINZA_MALA = 8
+
 
     @staticmethod
     def is_command(value: int) -> bool:

--- a/ros_workspace/src/proyecto/src/control_robot.py
+++ b/ros_workspace/src/proyecto/src/control_robot.py
@@ -63,13 +63,18 @@ class ControlRobot:
             rospy.loginfo("Caja 2 abajo")
             self.move_to_specific_position("caja_2_abajo")
         elif command == Command.ABRIR_PINZA.value:
+            rospy.loginfo("Abrir pinza")
             self.mover_pinza(100.0, 40.0)
         elif command == Command.CERRAR_PINZA.value:
             self.mover_pinza(0.0, 40.0)
+            rospy.loginfo("Cerrar pinza")
+        elif command == Command.CERRAR_PINZA_MALA.value:
+            rospy.loginfo("Cerrar pinza lentamente")
+            self.mover_pinza(0.0, 20.0)
         else:
             rospy.logwarn("Comando no reconocido")
 
-        rospy.sleep(1)
+        rospy.sleep(1) # Change if necessary
 
     def handle_joint_states(self, msg: JointState) -> None:
 
@@ -139,7 +144,8 @@ class ControlRobot:
 
         if action in joints:
             self.move_group.go(joints[action], wait=True)
-            
+
+    # Check the doc out http://docs.ros.org/en/hydro/api/ric_mc/html/GripperCommand_8h_source.html for GripperCommandGoal     
     def mover_pinza(self, anchura_dedos: float, fuerza: float) -> bool:
         goal = GripperCommandGoal()
         goal.command.position = anchura_dedos

--- a/ros_workspace/src/proyecto/src/controller.py
+++ b/ros_workspace/src/proyecto/src/controller.py
@@ -23,7 +23,7 @@ def poner_caja_mala():
     queue.push(Command.POSICION_INICIAL)
     queue.push(Command.ABRIR_PINZA)
     queue.push(Command.COGER_FRUTA)
-    queue.push(Command.CERRAR_PINZA)
+    queue.push(Command.CERRAR_PINZA_MALA)
     queue.push(Command.CAJA_MALA_ARRIBA)
     queue.push(Command.CAJA_MALA_ABAJO)
     queue.push(Command.ABRIR_PINZA)


### PR DESCRIPTION
This pull request includes several changes to the robot control system, adding new functionality and improving logging. The most important changes include adding a new command for closing the gripper slowly, updating the command handling logic, and improving documentation.

New functionality and command handling:

* [`ros_workspace/src/proyecto/src/commands.py`](diffhunk://#diff-b0494477b4d093fc9003d4a3da8251081913214a6624c3513d27c1d0cac2538bR14-R15): Added a new command `CERRAR_PINZA_MALA` to the `Command` enum.
* [`ros_workspace/src/proyecto/src/control_robot.py`](diffhunk://#diff-3b48a1b437a464864b21b8d72bad21c24a385e653481c38f3d0f77dabfe2fff9R66-R77): Updated the `handle_command` method to handle the new `CERRAR_PINZA_MALA` command, including logging.
* [`ros_workspace/src/proyecto/src/controller.py`](diffhunk://#diff-409f082c2673c0ba4886cb3ce57b689450085a33726dea4a0d6953d809036155L26-R26): Modified the `poner_caja_mala` function to use the new `CERRAR_PINZA_MALA` command instead of `CERRAR_PINZA`.

Documentation improvements:

* [`ros_workspace/src/proyecto/src/control_robot.py`](diffhunk://#diff-3b48a1b437a464864b21b8d72bad21c24a385e653481c38f3d0f77dabfe2fff9R148): Added a comment with a link to the ROS documentation for `GripperCommandGoal` in the `mover_pinza` method.